### PR TITLE
feat(deleteReferences): Add dynamic parameters

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -27,13 +27,16 @@ function regexMatches(text: string, regex: Key): string[] {
   return text.match(new RegExp(regex, 'g')) || [];
 }
 
-export function getPrimaryKey(ref: string): string {
+export function getPrimaryKey(
+  ref: string
+): { hasPrimaryKey: boolean; primaryKey: string } {
   const keys = regexMatches(ref, Key.Primary);
   if (keys.length > 0) {
     const pk = keys.pop(); // Pop the last item in the matched array
-    return pk.replace(/\{|\}/g, ''); // Remove { } from the primary key
+    // Remove { } from the primary key
+    return { hasPrimaryKey: true, primaryKey: pk.replace(/\{|\}/g, '') };
   }
-  throw new Error('integrify: Missing a primary key in the source');
+  return { hasPrimaryKey: false, primaryKey: 'masterId' };
 }
 
 export function replaceReferencesWith(

--- a/src/common.ts
+++ b/src/common.ts
@@ -18,14 +18,30 @@ export function isConfig(arg: Rule | Config): arg is Config {
   return (arg as Config).config !== undefined;
 }
 
-export function replaceReferenceWithFields(
+enum Key {
+  Primary = '{(.*?)}',
+  Foreign = '([$][^/]*|$)',
+}
+
+function regexMatches(text: string, regex: Key): string[] {
+  return text.match(new RegExp(regex, 'g')) || [];
+}
+
+export function getPrimaryKey(ref: string): string {
+  const keys = regexMatches(ref, Key.Primary);
+  if (keys.length > 0) {
+    const pk = keys.pop(); // Pop the last item in the matched array
+    return pk.replace(/\{|\}/g, ''); // Remove { } from the primary key
+  }
+  throw new Error('integrify: Missing a primary key in the source');
+}
+
+export function replaceReferencesWith(
   fields: FirebaseFirestore.DocumentData,
   targetCollection: string
 ): { hasFields: boolean; targetCollection: string } {
-  const pRegex = /([\$][^\/]*|$)/g;
-  const matches = targetCollection.match(pRegex); // Using global flag always returns an empty string at the end
-  matches.pop();
-
+  const matches = regexMatches(targetCollection, Key.Foreign);
+  matches.pop(); // The foreign key regex always return '' at the end
   let hasFields = false;
   if (matches.length > 0 && fields) {
     hasFields = true;

--- a/src/common.ts
+++ b/src/common.ts
@@ -17,3 +17,37 @@ export function isRule(arg: Rule | Config): arg is Rule {
 export function isConfig(arg: Rule | Config): arg is Config {
   return (arg as Config).config !== undefined;
 }
+
+export function replaceReferenceWithMasterId(
+  targetRef: string,
+  masterId: string
+): string {
+  return targetRef.replace('{masterId}', masterId);
+}
+
+export function replaceReferenceWithFields(
+  fields: FirebaseFirestore.DocumentData,
+  targetCollection: string
+): { hasFields: boolean; targetCollection: string } {
+  const pRegex = /\{([^)]+)\}/g;
+  const matches = pRegex.exec(targetCollection);
+  let hasFields = false;
+  if (matches && fields) {
+    hasFields = true;
+    matches.forEach(() => {
+      const field = fields[matches[1]];
+      if (field) {
+        console.log(
+          `integrify: Detected dynamic reference, replacing [${matches[0]}] with [${field}]`
+        );
+        targetCollection = targetCollection.replace(matches[0], field);
+      } else {
+        throw new Error(
+          `integrify: Missing dynamic reference: [${matches[0]}]`
+        );
+      }
+    });
+  }
+
+  return { hasFields, targetCollection };
+}

--- a/src/rules/deleteReferences.ts
+++ b/src/rules/deleteReferences.ts
@@ -1,4 +1,9 @@
-import { Config, Rule } from '../common';
+import {
+  Config,
+  Rule,
+  replaceReferenceWithMasterId,
+  replaceReferenceWithFields,
+} from '../common';
 
 export interface DeleteReferencesRule extends Rule {
   source: {
@@ -55,6 +60,20 @@ export function integrifyDeleteReferences(
             target.foreignKey
           }] matches [${masterId}]`
         );
+
+        // Replace masterId in target collection
+        target.collection = replaceReferenceWithMasterId(
+          target.collection,
+          masterId
+        );
+
+        // Replace the fields in the target collection
+        const { hasFields, targetCollection } = replaceReferenceWithFields(
+          snap.data(),
+          target.collection
+        );
+        target.collection = targetCollection;
+
         // Delete all docs in this target corresponding to deleted master doc
         let whereable = null;
         if (target.isCollectionGroup) {
@@ -62,6 +81,7 @@ export function integrifyDeleteReferences(
         } else {
           whereable = db.collection(target.collection);
         }
+
         promises.push(
           whereable
             .where(target.foreignKey, '==', masterId)

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -73,7 +73,7 @@ module.exports.deleteReferencesWithMasterParam = integrify({
       foreignKey: 'masterId',
     },
     {
-      collection: 'somecoll/{masterId}/detail2',
+      collection: 'somecoll/$masterId/detail2',
       foreignKey: 'masterId',
     },
   ],
@@ -98,7 +98,32 @@ module.exports.deleteReferencesWithSnapshotFields = integrify({
       foreignKey: 'masterId',
     },
     {
-      collection: 'somecoll/{testId}/detail2',
+      collection: 'somecoll/$testId/detail2',
+      foreignKey: 'masterId',
+    },
+  ],
+  hooks: {
+    pre: (snap, context) => {
+      setState({
+        snap,
+        context,
+      });
+    },
+  },
+});
+
+module.exports.deleteReferencesWithMissingFields = integrify({
+  rule: 'DELETE_REFERENCES',
+  source: {
+    collection: 'master',
+  },
+  targets: [
+    {
+      collection: 'detail1',
+      foreignKey: 'masterId',
+    },
+    {
+      collection: 'somecoll/$testId/detail2',
       foreignKey: 'masterId',
     },
   ],

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -42,7 +42,7 @@ module.exports.replicateMasterToDetail = integrify({
 module.exports.deleteReferencesToMaster = integrify({
   rule: 'DELETE_REFERENCES',
   source: {
-    collection: 'master',
+    collection: 'master/{masterId}',
   },
   targets: [
     {
@@ -65,16 +65,16 @@ module.exports.deleteReferencesToMaster = integrify({
 module.exports.deleteReferencesWithMasterParam = integrify({
   rule: 'DELETE_REFERENCES',
   source: {
-    collection: 'master',
+    collection: 'master/{primaryKey}',
   },
   targets: [
     {
       collection: 'detail1',
-      foreignKey: 'masterId',
+      foreignKey: 'primaryKey',
     },
     {
-      collection: 'somecoll/$masterId/detail2',
-      foreignKey: 'masterId',
+      collection: 'somecoll/$primaryKey/detail2',
+      foreignKey: 'primaryKey',
     },
   ],
   hooks: {
@@ -90,16 +90,37 @@ module.exports.deleteReferencesWithMasterParam = integrify({
 module.exports.deleteReferencesWithSnapshotFields = integrify({
   rule: 'DELETE_REFERENCES',
   source: {
+    collection: 'master/{anotherId}',
+  },
+  targets: [
+    {
+      collection: 'detail1',
+      foreignKey: 'anotherId',
+    },
+    {
+      collection: 'somecoll/$testId/detail2',
+      foreignKey: 'anotherId',
+    },
+  ],
+  hooks: {
+    pre: (snap, context) => {
+      setState({
+        snap,
+        context,
+      });
+    },
+  },
+});
+
+module.exports.deleteReferencesWithMissingKey = integrify({
+  rule: 'DELETE_REFERENCES',
+  source: {
     collection: 'master',
   },
   targets: [
     {
       collection: 'detail1',
-      foreignKey: 'masterId',
-    },
-    {
-      collection: 'somecoll/$testId/detail2',
-      foreignKey: 'masterId',
+      foreignKey: 'randomId',
     },
   ],
   hooks: {
@@ -115,16 +136,16 @@ module.exports.deleteReferencesWithSnapshotFields = integrify({
 module.exports.deleteReferencesWithMissingFields = integrify({
   rule: 'DELETE_REFERENCES',
   source: {
-    collection: 'master',
+    collection: 'master/{randomId}',
   },
   targets: [
     {
       collection: 'detail1',
-      foreignKey: 'masterId',
+      foreignKey: 'randomId',
     },
     {
       collection: 'somecoll/$testId/detail2',
-      foreignKey: 'masterId',
+      foreignKey: 'randomId',
     },
   ],
   hooks: {

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -62,6 +62,56 @@ module.exports.deleteReferencesToMaster = integrify({
   },
 });
 
+module.exports.deleteReferencesWithMasterParam = integrify({
+  rule: 'DELETE_REFERENCES',
+  source: {
+    collection: 'master',
+  },
+  targets: [
+    {
+      collection: 'detail1',
+      foreignKey: 'masterId',
+    },
+    {
+      collection: 'somecoll/{masterId}/detail2',
+      foreignKey: 'masterId',
+    },
+  ],
+  hooks: {
+    pre: (snap, context) => {
+      setState({
+        snap,
+        context,
+      });
+    },
+  },
+});
+
+module.exports.deleteReferencesWithSnapshotFields = integrify({
+  rule: 'DELETE_REFERENCES',
+  source: {
+    collection: 'master',
+  },
+  targets: [
+    {
+      collection: 'detail1',
+      foreignKey: 'masterId',
+    },
+    {
+      collection: 'somecoll/{testId}/detail2',
+      foreignKey: 'masterId',
+    },
+  ],
+  hooks: {
+    pre: (snap, context) => {
+      setState({
+        snap,
+        context,
+      });
+    },
+  },
+});
+
 module.exports.maintainFavoritesCount = integrify({
   rule: 'MAINTAIN_COUNT',
   source: {

--- a/test/functions/integrify.rules.js
+++ b/test/functions/integrify.rules.js
@@ -57,7 +57,7 @@ module.exports = [
         foreignKey: 'masterId',
       },
       {
-        collection: 'somecoll/{masterId}/detail2',
+        collection: 'somecoll/$masterId/detail2',
         foreignKey: 'masterId',
       },
     ],
@@ -74,7 +74,24 @@ module.exports = [
         foreignKey: 'masterId',
       },
       {
-        collection: 'somecoll/{testId}/detail2',
+        collection: 'somecoll/$testId/detail2',
+        foreignKey: 'masterId',
+      },
+    ],
+  },
+  {
+    rule: 'DELETE_REFERENCES',
+    name: 'deleteReferencesWithMissingFields',
+    source: {
+      collection: 'master',
+    },
+    targets: [
+      {
+        collection: 'detail1',
+        foreignKey: 'masterId',
+      },
+      {
+        collection: 'somecoll/$testId/detail2',
         foreignKey: 'masterId',
       },
     ],

--- a/test/functions/integrify.rules.js
+++ b/test/functions/integrify.rules.js
@@ -46,6 +46,40 @@ module.exports = [
     ],
   },
   {
+    rule: 'DELETE_REFERENCES',
+    name: 'deleteReferencesWithMasterParam',
+    source: {
+      collection: 'master',
+    },
+    targets: [
+      {
+        collection: 'detail1',
+        foreignKey: 'masterId',
+      },
+      {
+        collection: 'somecoll/{masterId}/detail2',
+        foreignKey: 'masterId',
+      },
+    ],
+  },
+  {
+    rule: 'DELETE_REFERENCES',
+    name: 'deleteReferencesWithSnapshotFields',
+    source: {
+      collection: 'master',
+    },
+    targets: [
+      {
+        collection: 'detail1',
+        foreignKey: 'masterId',
+      },
+      {
+        collection: 'somecoll/{testId}/detail2',
+        foreignKey: 'masterId',
+      },
+    ],
+  },
+  {
     rule: 'MAINTAIN_COUNT',
     name: 'maintainFavoritesCount',
     source: {

--- a/test/functions/integrify.rules.js
+++ b/test/functions/integrify.rules.js
@@ -31,7 +31,7 @@ module.exports = [
     rule: 'DELETE_REFERENCES',
     name: 'deleteReferencesToMaster',
     source: {
-      collection: 'master',
+      collection: 'master/{masterId}',
     },
     targets: [
       {
@@ -49,16 +49,16 @@ module.exports = [
     rule: 'DELETE_REFERENCES',
     name: 'deleteReferencesWithMasterParam',
     source: {
-      collection: 'master',
+      collection: 'master/{primaryKey}',
     },
     targets: [
       {
         collection: 'detail1',
-        foreignKey: 'masterId',
+        foreignKey: 'primaryKey',
       },
       {
-        collection: 'somecoll/$masterId/detail2',
-        foreignKey: 'masterId',
+        collection: 'somecoll/$primaryKey/detail2',
+        foreignKey: 'primaryKey',
       },
     ],
   },
@@ -66,16 +66,29 @@ module.exports = [
     rule: 'DELETE_REFERENCES',
     name: 'deleteReferencesWithSnapshotFields',
     source: {
+      collection: 'master/{anotherId}',
+    },
+    targets: [
+      {
+        collection: 'detail1',
+        foreignKey: 'anotherId',
+      },
+      {
+        collection: 'somecoll/$testId/detail2',
+        foreignKey: 'anotherId',
+      },
+    ],
+  },
+  {
+    rule: 'DELETE_REFERENCES',
+    name: 'deleteReferencesWithMissingKey',
+    source: {
       collection: 'master',
     },
     targets: [
       {
         collection: 'detail1',
-        foreignKey: 'masterId',
-      },
-      {
-        collection: 'somecoll/$testId/detail2',
-        foreignKey: 'masterId',
+        foreignKey: 'randomId',
       },
     ],
   },
@@ -83,16 +96,16 @@ module.exports = [
     rule: 'DELETE_REFERENCES',
     name: 'deleteReferencesWithMissingFields',
     source: {
-      collection: 'master',
+      collection: 'master/{randomId}',
     },
     targets: [
       {
         collection: 'detail1',
-        foreignKey: 'masterId',
+        foreignKey: 'randomId',
       },
       {
         collection: 'somecoll/$testId/detail2',
-        foreignKey: 'masterId',
+        foreignKey: 'randomId',
       },
     ],
   },

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -51,13 +51,13 @@ testsuites.forEach(testsuite => {
     t.true(sut.replicateMasterToDetail.name === 'cloudFunction');
     t.truthy(sut.replicateMasterToDetail.run);
   });
-  test(`[${name}] test basic variable swap`, async t =>
+  test(`[${name}] test target collection parameter swap`, async t =>
     testVariableSwap(sut, t, name));
-  test(`[${name}] test simple replicate attributes`, async t =>
+  test(`[${name}] test replicate attributes`, async t =>
     testReplicateAttributes(sut, t, name));
-  test(`[${name}] test simple delete references`, async t =>
+  test(`[${name}] test delete references`, async t =>
     testDeleteReferences(sut, t, name));
-  test(`[${name}] test simple maintain count`, async t =>
+  test(`[${name}] test maintain count`, async t =>
     testMaintainCount(sut, t));
 
   test(`[${name}] test delete with masterId in target reference`, async t =>

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -57,8 +57,7 @@ testsuites.forEach(testsuite => {
     testReplicateAttributes(sut, t, name));
   test(`[${name}] test delete references`, async t =>
     testDeleteReferences(sut, t, name));
-  test(`[${name}] test maintain count`, async t =>
-    testMaintainCount(sut, t));
+  test(`[${name}] test maintain count`, async t => testMaintainCount(sut, t));
 
   test(`[${name}] test delete with masterId in target reference`, async t =>
     testDeleteParamReferences(sut, t, name));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -74,22 +74,22 @@ testsuites.forEach(testsuite => {
 async function testPrimaryKey(sut, t, name) {
   // Test one key
   let targetCollection = 'collection/{collectionId}';
-  let primaryKey = getPrimaryKey(targetCollection);
+  let result = getPrimaryKey(targetCollection);
 
-  t.is(primaryKey, 'collectionId');
+  t.true(result.hasPrimaryKey);
+  t.is(result.primaryKey, 'collectionId');
 
   // Test two keys
   targetCollection = 'collection/{collectionId}/some_detail/{detailId}';
-  primaryKey = getPrimaryKey(targetCollection);
-  t.is(primaryKey, 'detailId');
+  result = getPrimaryKey(targetCollection);
+  t.true(result.hasPrimaryKey);
+  t.is(result.primaryKey, 'detailId');
 
   // Test missing key
   targetCollection = 'collection';
-
-  const error = t.throws(() => {
-    getPrimaryKey(targetCollection);
-  });
-  t.is(error.message, 'integrify: Missing a primary key in the source');
+  result = getPrimaryKey(targetCollection);
+  t.false(result.hasPrimaryKey);
+  t.is(result.primaryKey, 'masterId');
 
   await t.pass();
 }
@@ -430,7 +430,10 @@ async function testDeleteMissingSourceCollectionKey(sut, t, name) {
     });
   });
 
-  t.is(error.message, 'integrify: Missing a primary key in the source');
+  t.is(
+    error.message,
+    'integrify: Missing a primary key [masterId] in the source params'
+  );
 
   // Assert pre-hook was called (only for rules-in-situ)
   if (name === 'rules-in-situ') {


### PR DESCRIPTION
Added feature #1 

Can reference the masterId:
```
source: {
  collection: 'master',
},
targets: [{
    collection: 'detail1',
    foreignKey: 'masterId',
  },
  {
    collection: 'somecoll/{masterId}/detail2',
    foreignKey: 'masterId',
  },
],
```

Can reference the snapshot fields from the source collection (The keys of the field need to match the {} in the target otherwise it will skip it):
```
source: {
  collection: 'master',
},
targets: [{
    collection: 'detail1',
    foreignKey: 'masterId',
  },
  {
    collection: 'somecoll/{testId}/detail2',
    foreignKey: 'masterId',
  },
],
```