### PR TITLE
Flag to delete subcollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
 # 𝚒𝚗𝚝𝚎𝚐𝚛𝚒𝚏𝚢
 
-[![Build Status](https://travis-ci.com/anishkny/integrify.svg?branch=master)](https://travis-ci.com/anishkny/integrify)
-[![Coverage Status](https://coveralls.io/repos/github/anishkny/integrify/badge.svg?branch=master)](https://coveralls.io/github/anishkny/integrify?branch=master)
-[![Greenkeeper badge](https://badges.greenkeeper.io/anishkny/integrify.svg)](https://greenkeeper.io/)
-[![Security](https://img.shields.io/badge/security-GitHub-blue)](https://github.com/anishkny/integrify/network/alerts)
-[![npm package](https://img.shields.io/npm/v/integrify.svg)](https://www.npmjs.com/package/integrify)
-[![Mentioned in Awesome Firebase](https://awesome.re/mentioned-badge.svg)](https://github.com/jthegedus/awesome-firebase)
 
 🤝 Enforce referential and data integrity in [Cloud Firestore](https://firebase.google.com/docs/firestore/) using [triggers](https://firebase.google.com/docs/functions/firestore-events)
 
-[Introductory blog post](https://dev.to/anishkny/---firestore-referential-integrity-via-triggers-kpb)
+This library was forked from [anishkny/integrify](https://github.com/anishkny/integrify)
 
 ## Usage
+
+#### REPLICATE
 
 ```js
 // index.js
@@ -61,20 +57,42 @@ module.exports.replicateMasterToDetail = integrify({
     },
   },
 });
+```
+
+#### DELETE
+
+```js
+// index.js
+
+const { integrify } = require('integrify');
+
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+const db = admin.firestore();
+
+integrify({ config: { functions, db } });
 
 // Automatically delete stale references
 module.exports.deleteReferencesToMaster = integrify({
   rule: 'DELETE_REFERENCES',
   source: {
-    collection: 'master',
+    collection: 'master', // <-- This will append {masterId}
+    // OR
+    collection: 'master/{masterId}', // <-- Can be any string as in Firebase
   },
   targets: [
     {
       collection: 'detail1',
-      foreignKey: 'masterId',
-
-      // Optional:
-      isCollectionGroup: true, // Delete from collection group, see more below
+      foreignKey: 'masterId', // Optional: Delete document with matching foreign key
+      deleteAll: false, // Optional: Delete all from sub-collection
+      // EITHER 'foreignKey' OR 'deleteAll' MUST BE PROVIDED
+      isCollectionGroup: true,  // Optional: Delete from collection group, see more below
+    },
+    {
+      collection: 'detail1/$master/details', // Can reference source ID, will throw error if it doesn't exist
+      // OR
+      collection: 'detail1/$fieldValue/details', // Can reference a field value, will throw error if it doesn't exist
     },
   ],
 
@@ -86,6 +104,21 @@ module.exports.deleteReferencesToMaster = integrify({
     },
   },
 });
+```
+
+#### MAINTAIN COUNT
+
+```js
+// index.js
+
+const { integrify } = require('integrify');
+
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+const db = admin.firestore();
+
+integrify({ config: { functions, db } });
 
 // Automatically maintain count
 module.exports.maintainFavoritesCount = integrify({

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module.exports.deleteReferencesToMaster = integrify({
     {
       collection: 'detail1',
       foreignKey: 'masterId', // Optional: Delete document with matching foreign key
-      deleteAll: false, // Optional: Delete all from sub-collection
+      deleteAll: false, // Optional: Delete all from collection
       // EITHER 'foreignKey' OR 'deleteAll' MUST BE PROVIDED
       isCollectionGroup: true,  // Optional: Delete from collection group, see more below
     },

--- a/src/common.ts
+++ b/src/common.ts
@@ -18,13 +18,6 @@ export function isConfig(arg: Rule | Config): arg is Config {
   return (arg as Config).config !== undefined;
 }
 
-export function isSubCollection(collection: string): boolean {
-  const filteredCollections = collection.split('/').filter(c => c.length > 0);
-  const numCollections = filteredCollections.length;
-  // Return false is equal to 1 or an even number
-  return numCollections !== 1 && numCollections % 2 === 1;
-}
-
 enum Key {
   Primary = '{(.*?)}',
   Foreign = '([$][^/]*|$)',

--- a/src/common.ts
+++ b/src/common.ts
@@ -18,6 +18,13 @@ export function isConfig(arg: Rule | Config): arg is Config {
   return (arg as Config).config !== undefined;
 }
 
+export function isSubCollection(collection: string): boolean {
+  const filteredCollections = collection.split('/').filter(c => c.length > 0);
+  const numCollections = filteredCollections.length;
+  // Return false is equal to 1 or an even number
+  return numCollections !== 1 && numCollections % 2 === 1;
+}
+
 enum Key {
   Primary = '{(.*?)}',
   Foreign = '([$][^/]*|$)',

--- a/src/rules/deleteReferences.ts
+++ b/src/rules/deleteReferences.ts
@@ -1,10 +1,4 @@
-import {
-  Config,
-  Rule,
-  replaceReferencesWith,
-  getPrimaryKey,
-  isSubCollection,
-} from '../common';
+import { Config, Rule, replaceReferencesWith, getPrimaryKey } from '../common';
 
 export interface DeleteReferencesRule extends Rule {
   source: {
@@ -79,10 +73,6 @@ export function integrifyDeleteReferences(
         if (!target.deleteAll && target.foreignKey.trim().length === 0) {
           throw new Error(
             `integrify: missing foreign key or set deleteAll to true`
-          );
-        } else if (target.deleteAll && !isSubCollection(target.collection)) {
-          throw new Error(
-            `integrify: [${target.collection}] is an invalid sub-collection`
           );
         }
 

--- a/src/rules/deleteReferences.ts
+++ b/src/rules/deleteReferences.ts
@@ -1,4 +1,10 @@
-import { Config, Rule, replaceReferencesWith, getPrimaryKey } from '../common';
+import {
+  Config,
+  Rule,
+  replaceReferencesWith,
+  getPrimaryKey,
+  isSubCollection,
+} from '../common';
 
 export interface DeleteReferencesRule extends Rule {
   source: {
@@ -6,8 +12,9 @@ export interface DeleteReferencesRule extends Rule {
   };
   targets: {
     collection: string;
-    foreignKey: string;
+    foreignKey?: string;
     isCollectionGroup?: boolean;
+    deleteAll?: boolean;
   }[];
   hooks?: {
     pre?: Function;
@@ -60,13 +67,24 @@ export function integrifyDeleteReferences(
       // Loop over each target
       const db = config.config.db;
       rule.targets.forEach(target => {
-        console.log(
-          `integrify: Deleting all docs in collection ${
-            target.isCollectionGroup ? 'group ' : ''
-          }[${target.collection}] where foreign key [${
-            target.foreignKey
-          }] matches [${primaryKeyValue}]`
-        );
+        // Check delete all flag
+        if (!target.deleteAll) {
+          target.deleteAll = false;
+        }
+        // CHeck the foreign key
+        if (!target.foreignKey) {
+          target.foreignKey = '';
+        }
+
+        if (!target.deleteAll && target.foreignKey.trim().length === 0) {
+          throw new Error(
+            `integrify: missing foreign key or set deleteAll to true`
+          );
+        } else if (target.deleteAll && !isSubCollection(target.collection)) {
+          throw new Error(
+            `integrify: [${target.collection}] is an invalid sub-collection`
+          );
+        }
 
         // Replace the context.params in the target collection
         const paramSwap = replaceReferencesWith(
@@ -89,20 +107,33 @@ export function integrifyDeleteReferences(
           whereable = db.collection(target.collection);
         }
 
+        if (target.deleteAll) {
+          console.log(
+            `integrify: Deleting all docs in sub-collection [${target.collection}]`
+          );
+        } else {
+          console.log(
+            `integrify: Deleting all docs in collection ${
+              target.isCollectionGroup ? 'group ' : ''
+            }[${target.collection}] where foreign key [${
+              target.foreignKey
+            }] matches [${primaryKeyValue}]`
+          );
+
+          whereable = whereable.where(target.foreignKey, '==', primaryKeyValue);
+        }
+
         promises.push(
-          whereable
-            .where(target.foreignKey, '==', primaryKeyValue)
-            .get()
-            .then(querySnap => {
-              querySnap.forEach(doc => {
-                console.log(
-                  `integrify: Deleting [${target.collection}]${
-                    target.isCollectionGroup ? ' (group)' : ''
-                  }, id [${doc.id}]`
-                );
-                promises.push(doc.ref.delete());
-              });
-            })
+          whereable.get().then(querySnap => {
+            querySnap.forEach(doc => {
+              console.log(
+                `integrify: Deleting [${target.collection}]${
+                  target.isCollectionGroup ? ' (group)' : ''
+                }, id [${doc.id}]`
+              );
+              promises.push(doc.ref.delete());
+            });
+          })
         );
       });
       return Promise.all(promises);

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -158,6 +158,70 @@ module.exports.deleteReferencesWithMissingFields = integrify({
   },
 });
 
+module.exports.deleteReferencesDeleteAllSubCollections = integrify({
+  rule: 'DELETE_REFERENCES',
+  source: {
+    collection: 'master/{randomId}',
+  },
+  targets: [
+    {
+      collection: 'somecoll/$testId/detail2',
+      foreignKey: 'randomId',
+      deleteAll: true,
+    },
+  ],
+  hooks: {
+    pre: (snap, context) => {
+      setState({
+        snap,
+        context,
+      });
+    },
+  },
+});
+
+module.exports.deleteReferencesDeleteAllSubCollectionErrors = integrify({
+  rule: 'DELETE_REFERENCES',
+  source: {
+    collection: 'master/{randomId}',
+  },
+  targets: [
+    {
+      collection: 'master/details',
+      foreignKey: 'randomId',
+      deleteAll: true,
+    },
+  ],
+  hooks: {
+    pre: (snap, context) => {
+      setState({
+        snap,
+        context,
+      });
+    },
+  },
+});
+
+module.exports.deleteReferencesMissingArgumentsErrors = integrify({
+  rule: 'DELETE_REFERENCES',
+  source: {
+    collection: 'master/{randomId}',
+  },
+  targets: [
+    {
+      collection: 'master/details',
+    },
+  ],
+  hooks: {
+    pre: (snap, context) => {
+      setState({
+        snap,
+        context,
+      });
+    },
+  },
+});
+
 module.exports.maintainFavoritesCount = integrify({
   rule: 'MAINTAIN_COUNT',
   source: {

--- a/test/functions/integrify.rules.js
+++ b/test/functions/integrify.rules.js
@@ -110,6 +110,46 @@ module.exports = [
     ],
   },
   {
+    rule: 'DELETE_REFERENCES',
+    name: 'deleteReferencesDeleteAllSubCollections',
+    source: {
+      collection: 'master/{randomId}',
+    },
+    targets: [
+      {
+        collection: 'somecoll/$testId/detail2',
+        foreignKey: 'randomId',
+        deleteAll: true,
+      },
+    ],
+  },
+  {
+    rule: 'DELETE_REFERENCES',
+    name: 'deleteReferencesDeleteAllSubCollectionErrors',
+    source: {
+      collection: 'master/{randomId}',
+    },
+    targets: [
+      {
+        collection: 'master/details',
+        foreignKey: 'randomId',
+        deleteAll: true,
+      },
+    ],
+  },
+  {
+    rule: 'DELETE_REFERENCES',
+    name: 'deleteReferencesMissingArgumentsErrors',
+    source: {
+      collection: 'master/{randomId}',
+    },
+    targets: [
+      {
+        collection: 'master/details',
+      },
+    ],
+  },
+  {
     rule: 'MAINTAIN_COUNT',
     name: 'maintainFavoritesCount',
     source: {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -53,8 +53,6 @@ testsuites.forEach(testsuite => {
   });
   test(`[${name}] test get primary key`, async t =>
     testPrimaryKey(sut, t, name));
-  // test(`[${name}] test sub-collection check`, async t =>
-  //   testSubCollection(sut, t, name));
   test(`[${name}] test target collection parameter swap`, async t =>
     testTargetVariableSwap(sut, t, name));
   test(`[${name}] test replicate attributes`, async t =>
@@ -74,8 +72,6 @@ testsuites.forEach(testsuite => {
 
   test(`[${name}] test delete all sub-collections in target reference`, async t =>
     testDeleteAllSubCollections(sut, t, name));
-  // test(`[${name}] test delete all sub-collections in target reference error`, async t =>
-  //   testDeleteAllSubCollectionsError(sut, t, name));
 
   test(`[${name}] test delete missing arguments error`, async t =>
     testDeleteMissingArgumentsError(sut, t, name));
@@ -103,44 +99,6 @@ async function testPrimaryKey(sut, t, name) {
 
   await t.pass();
 }
-
-// async function testSubCollection(sut, t, name) {
-//   // Test zero key
-//   let result = isSubCollection('');
-//   t.false(result);
-
-//   // Test one key
-//   result = isSubCollection('collection');
-//   t.false(result);
-
-//   // Test two keys
-//   result = isSubCollection('collection1/collection2');
-//   t.false(result);
-
-//   // Test three keys
-//   result = isSubCollection('collection1/collection2/collection3');
-//   t.true(result);
-
-//   // Test four keys
-//   result = isSubCollection('collection1/collection2/collection3/collection4');
-//   t.false(result);
-
-//   // Test five keys
-//   result = isSubCollection(
-//     'collection1/collection2/collection3/collection4/collection5'
-//   );
-//   t.true(result);
-
-//   // Check incorrect format of collection
-//   result = isSubCollection('collection1//');
-//   t.false(result);
-//   result = isSubCollection('//collection1//');
-//   t.false(result);
-//   result = isSubCollection('collection1///collection2///collection3');
-//   t.true(result);
-
-//   await t.pass();
-// }
 
 async function testTargetVariableSwap(sut, t, name) {
   // test no fields

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -7,11 +7,7 @@ const fft = require('firebase-functions-test')(
 );
 const test = require('ava');
 const { integrify } = require('../lib');
-const {
-  replaceReferencesWith,
-  getPrimaryKey,
-  isSubCollection,
-} = require('../lib/common');
+const { replaceReferencesWith, getPrimaryKey } = require('../lib/common');
 const { getState, setState } = require('./functions/stateMachine');
 
 const admin = require('firebase-admin');
@@ -57,8 +53,8 @@ testsuites.forEach(testsuite => {
   });
   test(`[${name}] test get primary key`, async t =>
     testPrimaryKey(sut, t, name));
-  test(`[${name}] test sub-collection check`, async t =>
-    testSubCollection(sut, t, name));
+  // test(`[${name}] test sub-collection check`, async t =>
+  //   testSubCollection(sut, t, name));
   test(`[${name}] test target collection parameter swap`, async t =>
     testTargetVariableSwap(sut, t, name));
   test(`[${name}] test replicate attributes`, async t =>
@@ -78,8 +74,8 @@ testsuites.forEach(testsuite => {
 
   test(`[${name}] test delete all sub-collections in target reference`, async t =>
     testDeleteAllSubCollections(sut, t, name));
-  test(`[${name}] test delete all sub-collections in target reference error`, async t =>
-    testDeleteAllSubCollectionsError(sut, t, name));
+  // test(`[${name}] test delete all sub-collections in target reference error`, async t =>
+  //   testDeleteAllSubCollectionsError(sut, t, name));
 
   test(`[${name}] test delete missing arguments error`, async t =>
     testDeleteMissingArgumentsError(sut, t, name));
@@ -108,43 +104,43 @@ async function testPrimaryKey(sut, t, name) {
   await t.pass();
 }
 
-async function testSubCollection(sut, t, name) {
-  // Test zero key
-  let result = isSubCollection('');
-  t.false(result);
+// async function testSubCollection(sut, t, name) {
+//   // Test zero key
+//   let result = isSubCollection('');
+//   t.false(result);
 
-  // Test one key
-  result = isSubCollection('collection');
-  t.false(result);
+//   // Test one key
+//   result = isSubCollection('collection');
+//   t.false(result);
 
-  // Test two keys
-  result = isSubCollection('collection1/collection2');
-  t.false(result);
+//   // Test two keys
+//   result = isSubCollection('collection1/collection2');
+//   t.false(result);
 
-  // Test three keys
-  result = isSubCollection('collection1/collection2/collection3');
-  t.true(result);
+//   // Test three keys
+//   result = isSubCollection('collection1/collection2/collection3');
+//   t.true(result);
 
-  // Test four keys
-  result = isSubCollection('collection1/collection2/collection3/collection4');
-  t.false(result);
+//   // Test four keys
+//   result = isSubCollection('collection1/collection2/collection3/collection4');
+//   t.false(result);
 
-  // Test five keys
-  result = isSubCollection(
-    'collection1/collection2/collection3/collection4/collection5'
-  );
-  t.true(result);
+//   // Test five keys
+//   result = isSubCollection(
+//     'collection1/collection2/collection3/collection4/collection5'
+//   );
+//   t.true(result);
 
-  // Check incorrect format of collection
-  result = isSubCollection('collection1//');
-  t.false(result);
-  result = isSubCollection('//collection1//');
-  t.false(result);
-  result = isSubCollection('collection1///collection2///collection3');
-  t.true(result);
+//   // Check incorrect format of collection
+//   result = isSubCollection('collection1//');
+//   t.false(result);
+//   result = isSubCollection('//collection1//');
+//   t.false(result);
+//   result = isSubCollection('collection1///collection2///collection3');
+//   t.true(result);
 
-  await t.pass();
-}
+//   await t.pass();
+// }
 
 async function testTargetVariableSwap(sut, t, name) {
   // test no fields
@@ -639,72 +635,6 @@ async function testDeleteAllSubCollections(sut, t, name) {
       .collection('somecoll')
       .doc(testId)
       .collection('detail3')
-      .where('randomId', '==', randomId),
-    1
-  );
-
-  t.pass();
-}
-
-async function testDeleteAllSubCollectionsError(sut, t, name) {
-  // Create some docs referencing master doc
-  const randomId = makeid();
-  const testId = makeid();
-  const nestedDocRef = db.collection('somecoll').doc(testId);
-  await nestedDocRef.set({
-    x: 1,
-  });
-  await nestedDocRef.collection('detail2').add({
-    randomId: randomId,
-  });
-  await assertQuerySizeEventually(
-    db
-      .collection('somecoll')
-      .doc(testId)
-      .collection('detail2')
-      .where('randomId', '==', randomId),
-    1
-  );
-
-  // Trigger function to delete references
-  const snap = fft.firestore.makeDocumentSnapshot(
-    {
-      testId,
-    },
-    `master/${randomId}`
-  );
-  const wrapped = fft.wrap(sut.deleteReferencesDeleteAllSubCollectionErrors);
-  setState({
-    snap: null,
-    context: null,
-  });
-  const error = await t.throwsAsync(async () => {
-    await wrapped(snap, {
-      params: {
-        randomId: randomId,
-        testId: testId,
-      },
-    });
-  });
-  t.is(
-    error.message,
-    `integrify: [master/details] is an invalid sub-collection`
-  );
-
-  // Assert pre-hook was called (only for rules-in-situ)
-  if (name === 'rules-in-situ') {
-    const state = getState();
-    t.truthy(state.snap);
-    t.truthy(state.context);
-    t.is(state.context.params.randomId, randomId);
-  }
-
-  // Assert referencing docs were deleted
-  await assertQuerySizeEventually(
-    db
-      .collection('somecoll')
-      .doc(testId)
-      .collection('detail2')
       .where('randomId', '==', randomId),
     1
   );


### PR DESCRIPTION
Issue #5, added flag to delete all sub-collections. This made the foreign key optional. Added error checking so that either the flag has to be true or a foreign key provided. Only sub-collections can be deleted. Top collections cannot be.