### PR TITLE
Fix dynamic target collection path params bug

### DIFF
--- a/src/rules/deleteReferences.ts
+++ b/src/rules/deleteReferences.ts
@@ -68,16 +68,10 @@ export function integrifyDeleteReferences(
           }] matches [${primaryKeyValue}]`
         );
 
-        // Replace the context.params in the target collection
-        const paramSwap = replaceReferencesWith(
-          context.params,
-          target.collection
-        );
-
-        // Replace the snapshot fields in the target collection
+        // Replace the context.params and snapshot fields in the target collection
         const fieldSwap = replaceReferencesWith(
-          snap.data(),
-          paramSwap.targetCollection
+          { ...snap.data(), ...context.params },
+          target.collection
         );
         target.collection = fieldSwap.targetCollection;
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -378,7 +378,6 @@ async function testDeleteSnapshotFieldReferences(sut, t, name) {
   await wrapped(snap, {
     params: {
       anotherId: anotherId,
-      testId: testId,
     },
   });
 


### PR DESCRIPTION
```
{
    rule: 'DELETE_REFERENCES',
    name: 'deleteReferencesWithSnapshotFields',
    source: {
      collection: 'master/{anotherId}',
    },
    targets: [
      {
        collection: 'detail1',
        foreignKey: 'anotherId',
      },
      {
        collection: 'somecoll/$testId/detail2',
        foreignKey: 'anotherId',
      },
    ],
  },
```
The test for this was set up incorrectly. The `$testId` was being passed as a param. It should have been passed as part of the snapshot only. Had to change the way in which the collection variables were replaced.