### PR TITLE
Delete field from target when not in source

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ integrify({ config: { functions, db } });
 module.exports.replicateMasterToDetail = integrify({
   rule: 'REPLICATE_ATTRIBUTES',
   source: {
-    collection: 'master',
+    source: {
+    collection: 'master', // <-- This will append {masterId}
+    // OR
+    collection: 'master/{masterId}', // <-- Can be any string as in Firebase
+  },
   },
   targets: [
     {
@@ -35,6 +39,7 @@ module.exports.replicateMasterToDetail = integrify({
         masterField1: 'detail1Field1',
         masterField2: 'detail1Field2',
       },
+      deleteMissing: true, // Optional: Delete missing fields on update, defaults to false
     },
     {
       collection: 'detail2',

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ module.exports.replicateMasterToDetail = integrify({
         masterField1: 'detail1Field1',
         masterField2: 'detail1Field2',
       },
-      deleteMissing: true, // Optional: Delete missing fields on update, defaults to false
     },
     {
       collection: 'detail2',

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ module.exports.replicateMasterToDetail = integrify({
       collection: 'detail1',
       foreignKey: 'masterId',
       attributeMapping: {
-        masterField1: 'detail1Field1',
+        masterField1: 'detail1Field1', // If an field is missing after the update, the field will be deleted
         masterField2: 'detail1Field2',
       },
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integrify",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Enforce referential integrity in Firestore using Cloud Functions",
   "keywords": [
     "firebase",

--- a/src/rules/replicateAttributes.ts
+++ b/src/rules/replicateAttributes.ts
@@ -13,7 +13,6 @@ export interface ReplicateAttributesRule extends Rule {
       [sourceAttribute: string]: string;
     };
     isCollectionGroup?: boolean;
-    deleteMissing?: boolean;
   }[];
   hooks?: {
     pre?: Function;
@@ -99,23 +98,12 @@ export function integrifyReplicateAttributes(
       rule.targets.forEach(target => {
         const targetCollection = target.collection;
         const update = {};
-        let shouldDelete = false;
-
-        if (target.deleteMissing) {
-          shouldDelete = target.deleteMissing;
-        }
 
         // Create "update" mapping each changed attribute from source => target,
         // if delete is set delete field
         Object.keys(target.attributeMapping).forEach(changedAttribute => {
-          if (newValue[changedAttribute]) {
-            update[target.attributeMapping[changedAttribute]] =
-              newValue[changedAttribute];
-          } else if (shouldDelete) {
-            update[
-              target.attributeMapping[changedAttribute]
-            ] = FieldValue.delete();
-          }
+          update[target.attributeMapping[changedAttribute]] =
+            newValue[changedAttribute] || FieldValue.delete();
         });
 
         console.log(

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -39,6 +39,32 @@ module.exports.replicateMasterToDetail = integrify({
   },
 });
 
+module.exports.replicateMasterDeleteWhenEmpty = integrify({
+  rule: 'REPLICATE_ATTRIBUTES',
+  source: {
+    collection: 'master',
+  },
+  targets: [
+    {
+      collection: 'detail1',
+      foreignKey: 'tempId',
+      attributeMapping: {
+        masterDetail1: 'foreignDetail1',
+        masterDetail2: 'foreignDetail2',
+      },
+      deleteMissing: true,
+    },
+  ],
+  hooks: {
+    pre: (change, context) => {
+      setState({
+        change,
+        context,
+      });
+    },
+  },
+});
+
 module.exports.deleteReferencesToMaster = integrify({
   rule: 'DELETE_REFERENCES',
   source: {

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -42,7 +42,7 @@ module.exports.replicateMasterToDetail = integrify({
 module.exports.replicateMasterDeleteWhenEmpty = integrify({
   rule: 'REPLICATE_ATTRIBUTES',
   source: {
-    collection: 'master',
+    collection: 'master/{primaryKey}',
   },
   targets: [
     {
@@ -59,6 +59,30 @@ module.exports.replicateMasterDeleteWhenEmpty = integrify({
     pre: (change, context) => {
       setState({
         change,
+        context,
+      });
+    },
+  },
+});
+
+module.exports.replicateReferencesWithMissingKey = integrify({
+  rule: 'REPLICATE_ATTRIBUTES',
+  source: {
+    collection: 'master/{masterId}',
+  },
+  targets: [
+    {
+      collection: 'detail1',
+      foreignKey: 'randomId',
+      attributeMapping: {
+        masterDetail1: 'foreignDetail1',
+      },
+    },
+  ],
+  hooks: {
+    pre: (snap, context) => {
+      setState({
+        snap,
         context,
       });
     },

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -52,7 +52,6 @@ module.exports.replicateMasterDeleteWhenEmpty = integrify({
         masterDetail1: 'foreignDetail1',
         masterDetail2: 'foreignDetail2',
       },
-      deleteMissing: true,
     },
   ],
   hooks: {

--- a/test/functions/integrify.rules.js
+++ b/test/functions/integrify.rules.js
@@ -31,7 +31,7 @@ module.exports = [
     rule: 'REPLICATE_ATTRIBUTES',
     name: 'replicateMasterDeleteWhenEmpty',
     source: {
-      collection: 'master',
+      collection: 'master/{primaryKey}',
     },
     targets: [
       {
@@ -42,6 +42,22 @@ module.exports = [
           masterDetail2: 'foreignDetail2',
         },
         deleteMissing: true,
+      },
+    ],
+  },
+  {
+    rule: 'REPLICATE_ATTRIBUTES',
+    name: 'replicateReferencesWithMissingKey',
+    source: {
+      collection: 'master/{masterId}',
+    },
+    targets: [
+      {
+        collection: 'detail1',
+        foreignKey: 'randomId',
+        attributeMapping: {
+          masterDetail1: 'foreignDetail1',
+        },
       },
     ],
   },

--- a/test/functions/integrify.rules.js
+++ b/test/functions/integrify.rules.js
@@ -41,7 +41,6 @@ module.exports = [
           masterDetail1: 'foreignDetail1',
           masterDetail2: 'foreignDetail2',
         },
-        deleteMissing: true,
       },
     ],
   },

--- a/test/functions/integrify.rules.js
+++ b/test/functions/integrify.rules.js
@@ -28,6 +28,24 @@ module.exports = [
     ],
   },
   {
+    rule: 'REPLICATE_ATTRIBUTES',
+    name: 'replicateMasterDeleteWhenEmpty',
+    source: {
+      collection: 'master',
+    },
+    targets: [
+      {
+        collection: 'detail1',
+        foreignKey: 'tempId',
+        attributeMapping: {
+          masterDetail1: 'foreignDetail1',
+          masterDetail2: 'foreignDetail2',
+        },
+        deleteMissing: true,
+      },
+    ],
+  },
+  {
     rule: 'DELETE_REFERENCES',
     name: 'deleteReferencesToMaster',
     source: {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -17,7 +17,7 @@ admin.initializeApp({
 const db = admin.firestore();
 
 async function clearFirestore() {
-  const collections = ['detail1', 'detail2', 'somecoll'];
+  const collections = ['detail1', 'detail2', 'detail3', 'somecoll'];
   for (const collection of collections) {
     const { docs } = await admin
       .firestore()
@@ -55,14 +55,19 @@ testsuites.forEach(testsuite => {
     testPrimaryKey(sut, t, name));
   test(`[${name}] test target collection parameter swap`, async t =>
     testTargetVariableSwap(sut, t, name));
+
+  // Standard functionality
   test(`[${name}] test replicate attributes`, async t =>
     testReplicateAttributes(sut, t, name));
   test(`[${name}] test delete references`, async t =>
     testDeleteReferences(sut, t, name));
   test(`[${name}] test maintain count`, async t => testMaintainCount(sut, t));
 
+  // Added by GitLive
   test(`[${name}] test replicate attributes delete when field is not there`, async t =>
     testReplicateAttributesDeleteEmpty(sut, t, name));
+  test(`[${name}] test replicate attributes with missing primary key in source reference`, async t =>
+    testReplicateMissingSourceCollectionKey(sut, t, name));
 
   test(`[${name}] test delete with masterId in target reference`, async t =>
     testDeleteParamReferences(sut, t, name));
@@ -75,7 +80,6 @@ testsuites.forEach(testsuite => {
 
   test(`[${name}] test delete all sub-collections in target reference`, async t =>
     testDeleteAllSubCollections(sut, t, name));
-
   test(`[${name}] test delete missing arguments error`, async t =>
     testDeleteMissingArgumentsError(sut, t, name));
 });
@@ -233,9 +237,9 @@ async function testReplicateAttributes(sut, t, name) {
 
 async function testReplicateAttributesDeleteEmpty(sut, t, name) {
   // Add a couple of detail documents to follow master
-  const masterId = makeid();
+  const primaryKey = makeid();
   await db.collection('detail1').add({
-    tempId: masterId,
+    tempId: primaryKey,
     foreignDetail1: 'foreign_detail_1',
     foreignDetail2: 'foreign_detail_2',
   });
@@ -246,13 +250,13 @@ async function testReplicateAttributesDeleteEmpty(sut, t, name) {
       masterDetail1: 'after1',
       masterDetail2: 'after2',
     },
-    `master/${masterId}`
+    `master/${primaryKey}`
   );
   const afterSnap = fft.firestore.makeDocumentSnapshot(
     {
       masterDetail2: 'after3',
     },
-    `master/${masterId}`
+    `master/${primaryKey}`
   );
   const change = fft.makeChange(beforeSnap, afterSnap);
   const wrapped = fft.wrap(sut.replicateMasterDeleteWhenEmpty);
@@ -262,7 +266,7 @@ async function testReplicateAttributesDeleteEmpty(sut, t, name) {
   });
   await wrapped(change, {
     params: {
-      masterId: masterId,
+      primaryKey: primaryKey,
     },
   });
 
@@ -271,26 +275,95 @@ async function testReplicateAttributesDeleteEmpty(sut, t, name) {
     const state = getState();
     t.truthy(state.change);
     t.truthy(state.context);
-    t.is(state.context.params.masterId, masterId);
+    t.is(state.context.params.primaryKey, primaryKey);
   }
 
   // Assert that attributes get replicated to detail documents
   await assertQuerySizeEventually(
     db
       .collection('detail1')
-      .where('tempId', '==', masterId)
+      .where('tempId', '==', primaryKey)
       .where('foreignDetail1', '==', 'foreign_detail_1'),
     0
   );
   await assertQuerySizeEventually(
     db
       .collection('detail1')
-      .where('tempId', '==', masterId)
+      .where('tempId', '==', primaryKey)
       .where('foreignDetail2', '==', 'after3'),
     1
   );
 
   await t.pass();
+}
+
+async function testReplicateMissingSourceCollectionKey(sut, t, name) {
+  // Create some docs referencing master doc
+  const randomId = makeid();
+  await db.collection('detail1').add({
+    tempId: randomId,
+    foreignDetail1: 'foreign_detail_1',
+    foreignDetail2: 'foreign_detail_2',
+  });
+
+  // Trigger function to delete references
+  const beforeSnap = fft.firestore.makeDocumentSnapshot(
+    {
+      masterDetail1: 'after1',
+      masterDetail2: 'after2',
+    },
+    `master/${randomId}`
+  );
+  const afterSnap = fft.firestore.makeDocumentSnapshot(
+    {
+      masterDetail2: 'after3',
+    },
+    `master/${randomId}`
+  );
+  const change = fft.makeChange(beforeSnap, afterSnap);
+  const wrapped = fft.wrap(sut.replicateReferencesWithMissingKey);
+  setState({
+    snap: null,
+    context: null,
+  });
+
+  const error = await t.throwsAsync(async () => {
+    await wrapped(change, {
+      params: {
+        randomId: randomId,
+      },
+    });
+  });
+
+  t.is(
+    error.message,
+    'integrify: Missing a primary key [masterId] in the source params'
+  );
+
+  // Assert pre-hook was called (only for rules-in-situ)
+  if (name === 'rules-in-situ') {
+    const state = getState();
+    t.is(state.snap, null);
+    t.is(state.context, null);
+  }
+
+  // Assert referencing docs were not deleted
+  await assertQuerySizeEventually(
+    db
+      .collection('detail1')
+      .where('tempId', '==', randomId)
+      .where('foreignDetail1', '==', 'foreign_detail_1'),
+    1
+  );
+  await assertQuerySizeEventually(
+    db
+      .collection('detail1')
+      .where('tempId', '==', randomId)
+      .where('foreignDetail2', '==', 'foreign_detail_2'),
+    1
+  );
+
+  t.pass();
 }
 
 async function testDeleteReferences(sut, t, name) {


### PR DESCRIPTION
From issue #8, the new feature deletes a field in the target collection docs, the deleteMissing flag defaults to false. Field needs to be in the attribute mapping to be removed for example:

```
collection: 'detail1',
foreignKey: 'tempId',
attributeMapping: {
    masterDetail1: 'foreignDetail1',
    masterDetail2: 'foreignDetail2',
},
deleteMissing: true,
```

if the after snapshot is (master):
```
{ masterDetail1: 'some_new_detail' }
```
The `foreignDetail2` will be deleted from the target snapshot as `masterDetail2` is not there and maps to `foreignDetail2`