### PR TITLE
Add post hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ module.exports.replicateMasterToDetail = integrify({
       // Code to execute before replicating attributes
       // See: https://firebase.google.com/docs/functions/firestore-events
     },
+    post: (change, context) => {
+      // Code to execute after replicating attributes
+      // See: https://firebase.google.com/docs/functions/firestore-events
+    },
   },
 });
 ```
@@ -104,6 +108,10 @@ module.exports.deleteReferencesToMaster = integrify({
   hooks: {
     pre: (snap, context) => {
       // Code to execute before deleting references
+      // See: https://firebase.google.com/docs/functions/firestore-events
+    },
+    post: (snap, context) => {
+      // Code to execute after deleting references
       // See: https://firebase.google.com/docs/functions/firestore-events
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integrify",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Enforce referential integrity in Firestore using Cloud Functions",
   "keywords": [
     "firebase",
@@ -9,10 +9,10 @@
     "integrity",
     "functions"
   ],
-  "homepage": "https://github.com/anishkny/integrify",
+  "homepage": "https://github.com/GitLiveApp/integrify",
   "repository": {
     "type": "git",
-    "url": "https://github.com/anishkny/integrify.git"
+    "url": "https://github.com/GitLiveApp/integrify.git"
   },
   "license": "MIT",
   "author": {
@@ -117,5 +117,8 @@
         "section": "Tests"
       }
     ]
+  },
+  "publishConfig": { 
+    "registry": "https://npm.pkg.github.com/" 
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,9 +1,4 @@
-import { firestore, Change } from 'firebase-functions';
 import * as functions from 'firebase-functions';
-import {
-  DocumentSnapshot,
-  QueryDocumentSnapshot,
-} from 'firebase-functions/lib/providers/firestore';
 
 export interface Rule {
   rule: 'REPLICATE_ATTRIBUTES' | 'DELETE_REFERENCES' | 'MAINTAIN_COUNT';
@@ -17,10 +12,10 @@ export interface Config {
   };
 }
 
-export type PreHookFunction = (
-  change: DocumentSnapshot | Change<QueryDocumentSnapshot>,
+export type HookFunction<T> = (
+  change: T,
   context: functions.EventContext
-) => Promise<void> | void;
+) => Promise<T> | void;
 
 export function isRule(arg: Rule | Config): arg is Rule {
   return (arg as Rule).rule !== undefined;

--- a/src/common.ts
+++ b/src/common.ts
@@ -15,7 +15,7 @@ export interface Config {
 export type HookFunction<T> = (
   change: T,
   context: functions.EventContext
-) => Promise<T> | void;
+) => Promise<void> | void;
 
 export function isRule(arg: Rule | Config): arg is Rule {
   return (arg as Rule).rule !== undefined;

--- a/src/rules/deleteReferences.ts
+++ b/src/rules/deleteReferences.ts
@@ -1,11 +1,12 @@
 import {
   Config,
   Rule,
-  PreHookFunction,
+  HookFunction,
   replaceReferencesWith,
   getPrimaryKey,
 } from '../common';
 import { WriteBatch } from '../utils/WriteBatch';
+import { QueryDocumentSnapshot } from 'firebase-functions/lib/providers/firestore';
 
 export interface DeleteReferencesRule extends Rule {
   source: {
@@ -18,7 +19,8 @@ export interface DeleteReferencesRule extends Rule {
     deleteAll?: boolean;
   }[];
   hooks?: {
-    pre?: PreHookFunction;
+    pre?: HookFunction;
+    post?: HookFunction;
   };
 }
 
@@ -125,5 +127,11 @@ export function integrifyDeleteReferences(
         }
         await batchDelete.commit();
       }
+
+      // // Call "pre" hook if defined
+      // if (rule.hooks && rule.hooks.pre) {
+      //   await rule.hooks.pre(snap, context);
+      //   console.log(`integrify: Running pre-hook: ${rule.hooks.pre}`);
+      // }
     });
 }

--- a/src/rules/deleteReferences.ts
+++ b/src/rules/deleteReferences.ts
@@ -19,8 +19,8 @@ export interface DeleteReferencesRule extends Rule {
     deleteAll?: boolean;
   }[];
   hooks?: {
-    pre?: HookFunction;
-    post?: HookFunction;
+    pre?: HookFunction<QueryDocumentSnapshot>;
+    post?: HookFunction<QueryDocumentSnapshot>;
   };
 }
 
@@ -128,10 +128,10 @@ export function integrifyDeleteReferences(
         await batchDelete.commit();
       }
 
-      // // Call "pre" hook if defined
-      // if (rule.hooks && rule.hooks.pre) {
-      //   await rule.hooks.pre(snap, context);
-      //   console.log(`integrify: Running pre-hook: ${rule.hooks.pre}`);
-      // }
+      // Call "post" hook if defined
+      if (rule.hooks && rule.hooks.post) {
+        await rule.hooks.post(snap, context);
+        console.log(`integrify: Running post-hook: ${rule.hooks.post}`);
+      }
     });
 }

--- a/src/rules/replicateAttributes.ts
+++ b/src/rules/replicateAttributes.ts
@@ -18,8 +18,8 @@ export interface ReplicateAttributesRule extends Rule {
     isCollectionGroup?: boolean;
   }[];
   hooks?: {
-    pre?: HookFunction;
-    post?: HookFunction;
+    pre?: HookFunction<Change<QueryDocumentSnapshot>>;
+    post?: HookFunction<Change<QueryDocumentSnapshot>>;
   };
 }
 
@@ -142,10 +142,10 @@ export function integrifyReplicateAttributes(
         await batchUpdate.commit();
       }
 
-      // // Call "pre" hook if defined
-      // if (rule.hooks && rule.hooks.pre) {
-      //   await rule.hooks.pre(change, context);
-      //   console.log(`integrify: Running pre-hook: ${rule.hooks.pre}`);
-      // }
+      // Call "post" hook if defined
+      if (rule.hooks && rule.hooks.post) {
+        await rule.hooks.post(change, context);
+        console.log(`integrify: Running post-hook: ${rule.hooks.post}`);
+      }
     });
 }

--- a/src/rules/replicateAttributes.ts
+++ b/src/rules/replicateAttributes.ts
@@ -1,6 +1,8 @@
-import { Config, Rule, PreHookFunction, getPrimaryKey } from '../common';
+import { Config, Rule, HookFunction, getPrimaryKey } from '../common';
 import { firestore } from 'firebase-admin';
+import { Change } from 'firebase-functions';
 import { WriteBatch } from '../utils/WriteBatch';
+import { QueryDocumentSnapshot } from 'firebase-functions/lib/providers/firestore';
 const FieldValue = firestore.FieldValue;
 
 export interface ReplicateAttributesRule extends Rule {
@@ -16,7 +18,8 @@ export interface ReplicateAttributesRule extends Rule {
     isCollectionGroup?: boolean;
   }[];
   hooks?: {
-    pre?: PreHookFunction;
+    pre?: HookFunction;
+    post?: HookFunction;
   };
 }
 
@@ -138,5 +141,11 @@ export function integrifyReplicateAttributes(
         }
         await batchUpdate.commit();
       }
+
+      // // Call "pre" hook if defined
+      // if (rule.hooks && rule.hooks.pre) {
+      //   await rule.hooks.pre(change, context);
+      //   console.log(`integrify: Running pre-hook: ${rule.hooks.pre}`);
+      // }
     });
 }

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -1,5 +1,5 @@
 const { integrify } = require('../../lib');
-const { setState } = require('./stateMachine');
+const { setState, getState } = require('./stateMachine');
 
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
@@ -224,6 +224,14 @@ module.exports.deleteReferencesDeleteAllSubCollections = integrify({
       setState({
         snap,
         context,
+        pre_count: getState().pre_count + 1,
+      });
+    },
+    post: (snap, context) => {
+      setState({
+        snap,
+        context,
+        post_count: getState().pre_count + 1,
       });
     },
   },

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -82,6 +82,9 @@ testsuites.forEach(testsuite => {
     testDeleteAllSubCollections(sut, t, name));
   test(`[${name}] test delete missing arguments error`, async t =>
     testDeleteMissingArgumentsError(sut, t, name));
+
+  // test(`[${name}] test delete pre hook`, async t =>
+  //   testDeletePrePostHooks(sut, t, name));
 });
 
 async function testPrimaryKey(sut, t, name) {
@@ -759,6 +762,84 @@ async function testDeleteMissingArgumentsError(sut, t, name) {
   t.is(
     error.message,
     'integrify: missing foreign key or set deleteAll to true'
+  );
+
+  t.pass();
+}
+
+async function testDeletePrePostHooks(sut, t, name) {
+  // Create some docs referencing master doc
+  const randomId = makeid();
+  const testId = makeid();
+  const nestedDocRef = db.collection('somecoll').doc(testId);
+  await nestedDocRef.set({
+    values: ['first_id', testId, 'another_id'],
+  });
+  await nestedDocRef.collection('detail2').add({
+    randomId: randomId,
+  });
+  await nestedDocRef.collection('detail3').add({
+    randomId: randomId,
+  });
+  await assertQuerySizeEventually(
+    db
+      .collection('somecoll')
+      .doc(testId)
+      .collection('detail2')
+      .where('randomId', '==', randomId),
+    1
+  );
+  await assertQuerySizeEventually(
+    db
+      .collection('somecoll')
+      .doc(testId)
+      .collection('detail3')
+      .where('randomId', '==', randomId),
+    1
+  );
+
+  // Trigger function to delete references
+  const snap = fft.firestore.makeDocumentSnapshot(
+    {
+      testId,
+    },
+    `master/${randomId}`
+  );
+  const wrapped = fft.wrap(sut.deleteReferencesDeleteAllSubCollections);
+  setState({
+    snap: null,
+    context: null,
+  });
+  await wrapped(snap, {
+    params: {
+      randomId: randomId,
+    },
+  });
+
+  // Assert pre-hook was called (only for rules-in-situ)
+  if (name === 'rules-in-situ') {
+    const state = getState();
+    t.truthy(state.snap);
+    t.truthy(state.context);
+    t.is(state.context.params.randomId, randomId);
+  }
+
+  // Assert referencing docs were deleted
+  await assertQuerySizeEventually(
+    db
+      .collection('somecoll')
+      .doc(testId)
+      .collection('detail2')
+      .where('randomId', '==', randomId),
+    0
+  );
+  await assertQuerySizeEventually(
+    db
+      .collection('somecoll')
+      .doc(testId)
+      .collection('detail3')
+      .where('randomId', '==', randomId),
+    1
   );
 
   t.pass();


### PR DESCRIPTION
Needed to be able to run a function after the target collections had been modified. Now code can be run after using the post hook:
```
hooks: {
    pre: (change, context) => {
      // Code to execute before
    },
    post:  (change, context) => {
      // Code to execute after 
    },
},
```

Changed the `HookFunction` to use generics