### PR TITLE
Set return types

### DIFF
--- a/src/rules/deleteReferences.ts
+++ b/src/rules/deleteReferences.ts
@@ -7,6 +7,7 @@ import {
 } from '../common';
 import { WriteBatch } from '../utils/WriteBatch';
 import { QueryDocumentSnapshot } from '@google-cloud/firestore';
+import { CloudFunction } from 'firebase-functions';
 
 export interface DeleteReferencesRule extends Rule {
   source: {
@@ -31,7 +32,7 @@ export function isDeleteReferencesRule(arg: Rule): arg is DeleteReferencesRule {
 export function integrifyDeleteReferences(
   rule: DeleteReferencesRule,
   config: Config
-) {
+): CloudFunction<QueryDocumentSnapshot> {
   const functions = config.config.functions;
 
   rule.targets.forEach(target =>

--- a/src/rules/replicateAttributes.ts
+++ b/src/rules/replicateAttributes.ts
@@ -1,6 +1,6 @@
 import { Config, Rule, HookFunction, getPrimaryKey } from '../common';
 import { firestore } from 'firebase-admin';
-import { Change } from 'firebase-functions';
+import { CloudFunction, Change } from 'firebase-functions';
 import { WriteBatch } from '../utils/WriteBatch';
 import { QueryDocumentSnapshot } from '@google-cloud/firestore';
 const FieldValue = firestore.FieldValue;
@@ -32,7 +32,7 @@ export function isReplicateAttributesRule(
 export function integrifyReplicateAttributes(
   rule: ReplicateAttributesRule,
   config: Config
-) {
+): CloudFunction<Change<QueryDocumentSnapshot>> {
   const functions = config.config.functions;
 
   console.log(


### PR DESCRIPTION
Explicitly set the return values of `integrifyDeleteReferences` to `CloudFunction<QueryDocumentSnapshot>` and `integrifyReplicateAttributes` to `CloudFunction<Change<QueryDocumentSnapshot>>`